### PR TITLE
PrivateRoute에서Outlet 추가

### DIFF
--- a/src/routes/PrivateRoute.js
+++ b/src/routes/PrivateRoute.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Outlet } from 'react-router-dom';
 
-const PrivateRoute = () => {
-  return <div>PrivateRoute 내용 추가</div>;
+const PrivateRoute = ({ permissionLevel }) => {
+  return <Outlet />;
 };
 
 export default PrivateRoute;


### PR DESCRIPTION
메인페이지와 로그인 회원가입 등의 페이지는 문제 없이 잘 보이지만, 지금 PrivateRoute 감싸진 페이지는 보이지 않을 겁니다.
문제 사항을 아래와 같이 해결했습니다.
<img width="434" alt="image" src="https://github.com/7CodeCrew/book-store-fe/assets/155948612/b1651417-acc5-4bdf-b6d9-d2f8d9488a43">
